### PR TITLE
Prevent users from limiting AZ subnet creation down to one zone

### DIFF
--- a/api/v1beta2/network_types.go
+++ b/api/v1beta2/network_types.go
@@ -271,7 +271,7 @@ type VPCSpec struct {
 	// than this number of AZs then this number of AZs will be picked randomly when creating
 	// default subnets. Defaults to 3
 	// +kubebuilder:default=3
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=2
 	AvailabilityZoneUsageLimit *int `json:"availabilityZoneUsageLimit,omitempty"`
 
 	// AvailabilityZoneSelection specifies how AZs should be selected if there are more AZs


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind api-change
-->

**What this PR does / why we need it**:

When creating a VPC for a cluster, the VPC network spec allows for availability zone creation to be limited all the way to a single zone. However, when this is done, the cluster fails to reconcile with the following error:

```
E0823 16:18:09.209597       1 controller.go:329] "Reconciler error" err="failed to reconcile control plane for AWSManagedControlPlane development-eks/eks-cluster-2-control-plane: failed to create cluster: couldn't create vpc config for cluster: subnets in at least 2 different az's are required" controller="awsmanagedcontrolplane" controllerGroup="controlplane.cluster.x-k8s.io" controllerKind="AWSManagedControlPlane" AWSManagedControlPlane="development-eks/eks-cluster-2-control-plane" namespace="development-eks" name="eks-cluster-2-control-plane" reconcileID="ba8ef0b0-57be-456f-b710-299f5c2a375c"
```

If this is not a supported action, maybe it should be disallowed by the API before the object is created.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
